### PR TITLE
set noneditable gasLimit gasPrice in wallet form

### DIFF
--- a/src/shared/wallet/contract/deploy.js
+++ b/src/shared/wallet/contract/deploy.js
@@ -16,6 +16,7 @@ import {BroadcastFail, BroadcastSuccess} from '../broadcastedTransaction';
 import {acceptableNonce, isValidBytes, onlyNumber} from '../validator';
 import type {GExecution} from '../../../server/gateways/iotex-core/iotex-core-types';
 import {clearButton, greenButton} from '../../common/buttons';
+import {INPUT_READONLY} from '../wallet';
 
 const window = require('global/window');
 const VERSION = 0x1;
@@ -371,6 +372,7 @@ export class Deploy extends Component {
             value={this.state.gasPrice}
             error={t(this.state.errors_gasPrice)}
             placeholder='0'
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 
@@ -380,6 +382,7 @@ export class Deploy extends Component {
             value={this.state.gasLimit}
             error={t(this.state.errors_gasLimit)}
             placeholder='100000'
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 

--- a/src/shared/wallet/contract/interact.js
+++ b/src/shared/wallet/contract/interact.js
@@ -12,6 +12,7 @@ import {BroadcastFail, BroadcastSuccess} from '../broadcastedTransaction';
 import {Dialogue} from '../../common/dialogue/dialogue';
 import type {GExecution} from '../../../server/gateways/iotex-core/iotex-core-types';
 import {cancelButton, clearButton, greenButton} from '../../common/buttons';
+import {INPUT_READONLY} from '../wallet';
 import {AbiFunctions} from './abi-functions';
 
 export class Interact extends Component {
@@ -403,6 +404,7 @@ export class Interact extends Component {
             value={this.state.gasPrice}
             error={t(this.state.errors_gasPrice)}
             placeholder='0'
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 
@@ -412,6 +414,7 @@ export class Interact extends Component {
             value={this.state.gasLimit}
             error={t(this.state.errors_gasLimit)}
             placeholder='100000'
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 

--- a/src/shared/wallet/transfer/transfer-input.js
+++ b/src/shared/wallet/transfer/transfer-input.js
@@ -14,6 +14,7 @@ import type {TRawTransferRequest} from '../../../entities/explorer-types';
 import {BroadcastFail, BroadcastSuccess} from '../broadcastedTransaction';
 import {clearButton, greenButton} from '../../common/buttons';
 import {decodeAddress} from '../../../lib/decode-address';
+import {INPUT_READONLY} from '../wallet';
 import {ContinueDeposit} from './continue-deposit';
 
 function getChainId(rawAddress) {
@@ -239,6 +240,7 @@ export class TransferInput extends Component {
             value={this.state.gasPrice}
             error={t(this.state.errors_gasPrice)}
             placeholder='0'
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 
@@ -248,6 +250,7 @@ export class TransferInput extends Component {
             value={this.state.gasLimit}
             error={t(this.state.errors_gasLimit)}
             placeholder={0}
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 

--- a/src/shared/wallet/vote/vote-input.js
+++ b/src/shared/wallet/vote/vote-input.js
@@ -13,6 +13,7 @@ import {acceptableNonce, isValidRawAddress, onlyNumber} from '../validator';
 import type {TRawVoteRequest} from '../../../entities/explorer-types';
 import {BroadcastFail, BroadcastSuccess} from '../broadcastedTransaction';
 import {clearButton, greenButton} from '../../common/buttons';
+import {INPUT_READONLY} from '../wallet';
 
 const PROTOCOL_VERSION = 0x01;
 
@@ -186,6 +187,7 @@ export class VoteInput extends Component {
             value={this.state.gasPrice}
             error={t(this.state.errors_gasPrice)}
             placeholder='0'
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 
@@ -195,6 +197,7 @@ export class VoteInput extends Component {
             value={this.state.gasLimit}
             error={t(this.state.errors_gasLimit)}
             placeholder={0}
+            readOnly={INPUT_READONLY}
             update={(name, value) => this.handleInputChange(name, value)}
           />
 

--- a/src/shared/wallet/wallet.js
+++ b/src/shared/wallet/wallet.js
@@ -20,6 +20,8 @@ const TRANSFER = 0;
 const VOTE = 1;
 const CONTRACT = 2;
 
+export const INPUT_READONLY = 'disabled';
+
 export class Wallet extends Component {
   props: {
     fetchAddressId: fetchAddressId,


### PR DESCRIPTION
- to set editable for these inputs, 
update in src/shared/wallet/wallet.js
export const INPUT_READONLY = false;