### PR TITLE
Fix #257 Apply full width to spin outside of table so that the table overflows only within itself

### DIFF
--- a/src/client/stylesheets/main.scss
+++ b/src/client/stylesheets/main.scss
@@ -196,3 +196,11 @@
     margin-bottom: 1.7em !important;
   }
 }
+
+.ant-table td {
+  white-space: nowrap;
+}
+
+.full-width-spin-preloader {
+  width: 100%;
+}

--- a/src/client/stylesheets/main.scss
+++ b/src/client/stylesheets/main.scss
@@ -197,10 +197,6 @@
   }
 }
 
-.ant-table td {
-  white-space: nowrap;
-}
-
 .full-width-spin-preloader {
   width: 100%;
 }

--- a/src/shared/action/action-detail.tsx
+++ b/src/shared/action/action-detail.tsx
@@ -35,7 +35,7 @@ export function buildKeyValueArray(object: {}): Array<{}> {
       return {
         key,
         // @ts-ignore
-        value: JSON.stringify(object[key])
+        value: <pre>{JSON.stringify(object[key], null, 2)}</pre>
       };
     }
     return {

--- a/src/shared/action/action-receipt.tsx
+++ b/src/shared/action/action-receipt.tsx
@@ -50,7 +50,10 @@ export class ActionReceipt extends Component<Props> {
           const dataSource = buildKeyValueArray(receipt);
 
           return (
-            <SpinPreloader spinning={loading}>
+            <SpinPreloader
+              spinning={loading}
+              wrapperClassName="full-width-spin-preloader"
+            >
               <Flex
                 width={"100%"}
                 column={true}
@@ -64,7 +67,7 @@ export class ActionReceipt extends Component<Props> {
                   columns={getColumns("")}
                   rowKey={"key"}
                   style={{ width: "100%" }}
-                  scroll={{ x: false }}
+                  scroll={{ x: true }}
                   showHeader={false}
                 />
               </Flex>

--- a/src/shared/common/spin-preloader.tsx
+++ b/src/shared/common/spin-preloader.tsx
@@ -7,11 +7,20 @@ const antIcon = <Icon type="loading" style={{ fontSize: 24 }} spin />;
 type Props = {
   children: JSX.Element | string | Array<JSX.Element>;
   spinning: boolean;
+  wrapperClassName?: string;
 };
 
-export function SpinPreloader({ children, spinning }: Props): JSX.Element {
+export function SpinPreloader({
+  children,
+  spinning,
+  wrapperClassName
+}: Props): JSX.Element {
   return (
-    <Spin spinning={spinning} indicator={antIcon}>
+    <Spin
+      spinning={spinning}
+      indicator={antIcon}
+      wrapperClassName={wrapperClassName}
+    >
       {children}
     </Spin>
   );


### PR DESCRIPTION
**What type of PR is this?**

/kind ui-change

**What this PR does / why we need it**:
The longest table cell (corresponding to log field of action receipt table) overflows from the screen and it needs a fix.

**Which issue(s) this PR fixes**:

Fixes #257 

**Special notes for your reviewer**:
This is my first PR. Feel free to let me know if there's anything done inappropriately.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
