### PR TITLE
Fixed #426: actions loading takes a long time

### DIFF
--- a/src/shared/actions/actions.tsx
+++ b/src/shared/actions/actions.tsx
@@ -53,7 +53,7 @@ type State = {
 };
 
 export class ActionTable extends Component<{}, State> {
-  public state: State = { start: 0, count: 30 };
+  public state: State = { start: 0, count: 15 };
   public render(): JSX.Element {
     const { count } = this.state;
     let { start } = this.state;
@@ -78,6 +78,7 @@ export class ActionTable extends Component<{}, State> {
             <Query
               query={GET_ACTIONS_BY_INDEX}
               variables={{ byIndex: { start, count } }}
+              notifyOnNetworkStatusChange={true}
             >
               {({
                 loading,


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #426 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
This page size of Actions table is reduced to 15 rows to optimize loading time. The loading spin would be shown each time pagination load.

![image](https://user-images.githubusercontent.com/6645185/57053473-80ab4100-6cb8-11e9-8554-403aa98e1fed.png)

```release-note

```
