### PR TITLE
Fixed #573: [wallet- transfer] query action_exist_by_hash poll shows lots of error

### DIFF
--- a/src/shared/common/apollo-error-handling.ts
+++ b/src/shared/common/apollo-error-handling.ts
@@ -3,12 +3,20 @@ import { onError } from "apollo-link-error";
 
 const onErrorLink = onError(error => {
   const { graphQLErrors, networkError, operation } = error;
-  if (operation.variables.ignoreErrorNotification || !operation.operationName) {
-    return;
-  }
   if (graphQLErrors) {
+    if (
+      operation.variables.ignoreErrorNotification ||
+      !operation.operationName
+    ) {
+      return;
+    }
     graphQLErrors.map(graphError => {
       const { message } = graphError;
+      // Disable notifying for not found error as a common case.
+      // The UI should handle this kind of error (if needed) specifically for each case.
+      if (`${message}`.match(/NOT_FOUND|not\s+exist\s+in\s+DB/i)) {
+        return;
+      }
       notification.error({
         key: operation.operationName,
         message: "Query error!",
@@ -17,6 +25,8 @@ const onErrorLink = onError(error => {
       });
     });
   }
+  // Always notify network error.
+  // It's helpful for user to check their connection conditional and retry.
   if (networkError) {
     notification.error({
       key: operation.operationName,


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #573 

**Special notes for your reviewer**:
The root cause of the issue is the general error handling will show notify for all the error happened. There is a common case that the user query for non-existing action, block, etc. for searching the target. Because the non-exist query is usual in-term of searching, the notify is unnecessary and annoying. This PR is to fix it.