### PR TITLE
Fixed #907: strange initial state of stats panel 

### DIFF
--- a/src/shared/home/stats/actions-card.tsx
+++ b/src/shared/home/stats/actions-card.tsx
@@ -1,47 +1,72 @@
 // @ts-ignore
+import gql from "graphql-tag";
 import { t } from "onefx/lib/iso-i18n";
-import React, { useState } from "react";
+import React from "react";
+import { Query, QueryResult } from "react-apollo";
+import { analyticsClient } from "../../common/apollo-client";
 import { assetURL } from "../../common/asset-url";
 import { colors } from "../../common/styles/style-color";
+import { GET_ANALYTICS_CHAIN } from "../../queries";
 import { CompAreaChart } from "../charts/area-chart";
-import { getActionsData } from "./map-card";
 import { StatsCard } from "./stats-card";
 
-const EMPTY_MAP_DATA: Array<{ name: string; value: number }> = [];
-
 export const ActionsCard = (): JSX.Element => {
-  const [mapData, setMapData] = useState(EMPTY_MAP_DATA);
-  const [epochNumber, setEpochNumber] = useState(0);
-  const [actions, setActions] = useState(0);
-  getActionsData()
-    .then(({ mapdata, currentEpochNumber, numberOfActions }) => {
-      if (currentEpochNumber !== epochNumber) {
-        setMapData(mapdata);
-        setEpochNumber(currentEpochNumber);
-        setActions(numberOfActions);
-      }
-    })
-    .catch(error => {
-      window.console.error(`failed to getActionsData: ${error}`);
-    });
   return (
-    <StatsCard
-      loading={!epochNumber}
-      title={t("home.stats.actions")}
-      titleStyle={{
-        backgroundImage: `url(${assetURL("/icon_overviw_TPS.png")})`
-      }}
-      value={`${actions.toLocaleString()}`}
-      prefix={
-        <div style={{ width: 46, height: 46 }}>
-          <CompAreaChart
-            data={mapData}
-            tinyMode={true}
-            fillColor={colors.warning}
+    <Query query={GET_ANALYTICS_CHAIN} client={analyticsClient}>
+      {({ error, loading, data }: QueryResult) => {
+        const showLoading = loading || !!error;
+        const { mostRecentEpoch = 0, numberOfActions = { count: 0 } } =
+          (data && data.chain) || {};
+        return (
+          <StatsCard
+            loading={showLoading}
+            title={t("home.stats.actions")}
+            titleStyle={{
+              backgroundImage: `url(${assetURL("/icon_overviw_TPS.png")})`
+            }}
+            value={`${numberOfActions.count.toLocaleString()}`}
+            prefix={
+              <div style={{ width: 46, height: 46 }}>
+                {mostRecentEpoch && (
+                  <Query
+                    client={analyticsClient}
+                    query={gql`{
+                    ${[1, 2, 3, 4, 5, 6, 7].map(day => {
+                      return `day${day}:chain{
+                        numberOfActions(pagination: { startEpoch: ${mostRecentEpoch -
+                          day * 24}, epochCount: 24 }) {
+                          count
+                        }
+                      }
+                      `;
+                    })}
+                  }
+                  `}
+                  >
+                    {({ data, error, loading }: QueryResult) => {
+                      if (error || loading || !data) {
+                        return null;
+                      }
+                      const mapdata = Object.keys(data).map((name, i) => ({
+                        name: `Day ${i + 1}`,
+                        value: data[name].numberOfActions.count
+                      }));
+                      return (
+                        <CompAreaChart
+                          data={mapdata}
+                          tinyMode={true}
+                          fillColor={colors.warning}
+                        />
+                      );
+                    }}
+                  </Query>
+                )}
+              </div>
+            }
+            suffix={``}
           />
-        </div>
-      }
-      suffix={``}
-    />
+        );
+      }}
+    </Query>
   );
 };

--- a/src/shared/home/stats/map-card.tsx
+++ b/src/shared/home/stats/map-card.tsx
@@ -1,12 +1,13 @@
-import { Card, Col, Row } from "antd";
+import { Card, Col, Icon, Row, Spin } from "antd";
 import gql from "graphql-tag";
 // @ts-ignore
 import { t } from "onefx/lib/iso-i18n";
-import React, { CSSProperties, useState } from "react";
-import { analyticsClient, webBpApolloClient } from "../../common/apollo-client";
+import React, { CSSProperties } from "react";
+import { Query, QueryResult } from "react-apollo";
+import { analyticsClient } from "../../common/apollo-client";
 import { assetURL } from "../../common/asset-url";
 import { colors } from "../../common/styles/style-color";
-import { GET_BP_STATS } from "../../queries";
+import { GET_ANALYTICS_CHAIN } from "../../queries";
 import { CompAreaChart } from "../charts/area-chart";
 
 const fontFamily = "'Heebo',sans-serif,Microsoft YaHei !important";
@@ -70,98 +71,69 @@ export const MapButton = (
   );
 };
 
-export const getActionsData = async (): Promise<{
-  mapdata: Array<{ name: string; value: number }>;
-  currentEpochNumber: number;
-  numberOfActions: number;
-}> => {
-  const {
-    data: {
-      stats: { currentEpochNumber }
-    }
-  } = await webBpApolloClient.query({
-    query: GET_BP_STATS
-  });
-
-  const query = gql`{
-    ${[1, 2, 3, 4, 5, 6, 7].map(day => {
-      return `day${day}:chain{
-        numberOfActions(pagination: { startEpoch: ${currentEpochNumber -
-          day * 24}, epochCount: 24 }) {
-          count
-        }
-      }
-      `;
-    })}
-    chain {
-      numberOfActions{
-        count
-      }
-    }
-  }
-  `;
-  const result: {
-    data: {
-      [index: string]: {
-        numberOfActions: {
-          count: number;
-        };
-      };
-    };
-  } = await analyticsClient.query({ query });
-  const { chain, ...chains } = result.data;
-  const numberOfActions = chain.numberOfActions.count;
-  const mapdata = Object.keys(chains).map((name, i) => ({
-    name: `Day ${i + 1}`,
-    value: result.data[name].numberOfActions.count
-  }));
-  return {
-    mapdata,
-    currentEpochNumber,
-    numberOfActions
-  };
-};
-
-const EMPTY_MAP_DATA: Array<{ name: string; value: number }> = [];
-
 export const MapCard = (): JSX.Element => {
-  const [mapData, setMapData] = useState(EMPTY_MAP_DATA);
-  const [epochNumber, setEpochNumber] = useState(0);
-  getActionsData()
-    .then(({ mapdata, currentEpochNumber }) => {
-      if (currentEpochNumber !== epochNumber) {
-        setMapData(mapdata);
-        setEpochNumber(currentEpochNumber);
-      }
-    })
-    .catch(error => {
-      window.console.error(`failed to getActionsData: ${error}`);
-    });
   return (
-    <Card style={Styles.mapBox} bodyStyle={Styles.mapBoxBody}>
-      <div style={{ padding: 10 }}>
-        {/* <Row type="flex" justify="space-around">
-          <Col span={12}>
-            <MapButton>{t("home.stats.map")}</MapButton>
-          </Col>
-          <Col span={12}>
-            <MapButton>{t("home.stats.energyConsumption")}</MapButton>
-          </Col>
-        </Row> */}
-        <Row type="flex" justify="start">
-          {/* <Col span={12}>
-            <MapButton>{t("home.stats.numberOfAddresses")}</MapButton>
-          </Col> */}
-          <Col span={12}>
-            <MapButton active={true}>
-              {t("home.stats.numberOfTransactions")}
-            </MapButton>
-          </Col>
-        </Row>
-      </div>
-      <div style={Styles.mapContainer}>
-        {mapData.length && <CompAreaChart data={mapData} />}
-      </div>
-    </Card>
+    <Query query={GET_ANALYTICS_CHAIN} client={analyticsClient}>
+      {({ error, loading, data }: QueryResult) => {
+        const showLoading = loading || !!error;
+        const { mostRecentEpoch = 0 } = (data && data.chain) || {};
+        return (
+          <Spin spinning={showLoading} indicator={<Icon type="loading" spin />}>
+            <Card style={Styles.mapBox} bodyStyle={Styles.mapBoxBody}>
+              <div style={{ padding: 10 }}>
+                {/* <Row type="flex" justify="space-around">
+                  <Col span={12}>
+                    <MapButton>{t("home.stats.map")}</MapButton>
+                  </Col>
+                  <Col span={12}>
+                    <MapButton>{t("home.stats.energyConsumption")}</MapButton>
+                  </Col>
+                </Row> */}
+                <Row type="flex" justify="start">
+                  {/* <Col span={12}>
+                    <MapButton>{t("home.stats.numberOfAddresses")}</MapButton>
+                  </Col> */}
+                  <Col span={12}>
+                    <MapButton active={true}>
+                      {t("home.stats.numberOfTransactions")}
+                    </MapButton>
+                  </Col>
+                </Row>
+              </div>
+              <div style={Styles.mapContainer}>
+                {mostRecentEpoch && (
+                  <Query
+                    client={analyticsClient}
+                    query={gql`{
+                    ${[1, 2, 3, 4, 5, 6, 7].map(day => {
+                      return `day${day}:chain{
+                        numberOfActions(pagination: { startEpoch: ${mostRecentEpoch -
+                          day * 24}, epochCount: 24 }) {
+                          count
+                        }
+                      }
+                      `;
+                    })}
+                  }
+                  `}
+                  >
+                    {({ data, error, loading }: QueryResult) => {
+                      if (error || loading || !data) {
+                        return null;
+                      }
+                      const mapdata = Object.keys(data).map((name, i) => ({
+                        name: `Day ${i + 1}`,
+                        value: data[name].numberOfActions.count
+                      }));
+                      return <CompAreaChart data={mapdata} />;
+                    }}
+                  </Query>
+                )}
+              </div>
+            </Card>
+          </Spin>
+        );
+      }}
+    </Query>
   );
 };

--- a/src/shared/queries.ts
+++ b/src/shared/queries.ts
@@ -430,3 +430,15 @@ export const GET_ANALYTICS_TPS = gql`
     }
   }
 `;
+
+export const GET_ANALYTICS_CHAIN = gql`
+  query chain {
+    chain {
+      mostRecentEpoch
+      mostRecentBlockHeight
+      numberOfActions {
+        count
+      }
+    }
+  }
+`;


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #907 

**Special notes for your reviewer**:
The root cause of the issue is that apollo client does not support SSR via query method so the initial state of stats is empty. 


**Does this PR introduce a user-facing change?**:
![image](https://user-images.githubusercontent.com/6645185/62151328-476f8500-b32a-11e9-93e8-17e1ee2f3263.png)

