### PR TITLE
Fixed #925: empty page

### DIFF
--- a/src/shared/address-details/address-details.tsx
+++ b/src/shared/address-details/address-details.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../api-gateway/resolvers/antenna-types";
 import { ITokenInfo, Token } from "../../erc20/token";
 import { CopyButtonClipboardComponent } from "../common/copy-button-clipboard";
-import { Navigation } from "../common/navigation";
 import { PageTitle } from "../common/page-title";
 import { ShowQrcodeButton } from "../common/show-qrcode-button";
 import { SpinPreloader } from "../common/spin-preloader";

--- a/src/shared/address-details/address-details.tsx
+++ b/src/shared/address-details/address-details.tsx
@@ -129,11 +129,8 @@ class AddressDetailsInner extends PureComponent<Props, State> {
     return (
       <ContentPadding>
         <Helmet title={`IoTeX ${t("address.address")} ${address}`} />
-        <Row style={{ marginTop: 60 }}>
-          <Col xs={12} style={{ marginTop: -8 }}>
-            <Navigation />
-          </Col>
-          <Col xs={12}>
+        <Row style={{ marginTop: 60 }} justify="end" type="flex">
+          <Col xs={24} md={12}>
             <SearchBox
               enterButton
               size="large"

--- a/src/shared/common/navigation.tsx
+++ b/src/shared/common/navigation.tsx
@@ -5,7 +5,6 @@ import withBreadcrumbs, {
 import { NavLink } from "react-router-dom";
 
 const routesConfig = [
-  { path: "/address", breadcrumb: "Address List" },
   { path: "/action", breadcrumb: "Action List" },
   { path: "/action/:hash", breadcrumb: "Action Detail" },
   { path: "/block", breadcrumb: "Block List" },


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #925 

**Special notes for your reviewer**:
The address list page is not available yet. This fix is meant to remove the breadcrumb from the address detail page.

**Does this PR introduce a user-facing change?**:
![Screen Shot 2019-08-05 at 11 05 03 PM](https://user-images.githubusercontent.com/6645185/62479290-5301f680-b7d7-11e9-8a69-8ca435853ad6.png)

