### PR TITLE
remind unlock wallet

### DIFF
--- a/src/shared/wallet/unlock-wallet-alert.tsx
+++ b/src/shared/wallet/unlock-wallet-alert.tsx
@@ -1,0 +1,60 @@
+import Button from "antd/lib/button";
+import Modal from "antd/lib/modal";
+import { Account } from "iotex-antenna/lib/account/account";
+import isElectron from "is-electron";
+// @ts-ignore
+import { t } from "onefx/lib/iso-i18n";
+import React, { useEffect, useState } from "react";
+import { connect } from "react-redux";
+
+import { IWalletState, SignParams } from "./wallet-reducer";
+
+// tslint:disable-next-line: no-any
+interface Props extends React.ComponentProps<any> {
+  signParams: SignParams;
+  account?: Account;
+}
+
+const UnlockWallet = ({
+  account,
+  signParams,
+  children
+}: Props): JSX.Element => {
+  const isUnlocked =
+    isElectron() && !account && !!signParams && !!signParams.reqId;
+  const [isVisible, setIsVisible] = useState(isUnlocked);
+
+  useEffect(() => {
+    setIsVisible(isUnlocked);
+  }, [account, signParams]);
+
+  return (
+    <>
+      {children}
+      <Modal
+        title={t("wallet.unlock_alert.title")}
+        visible={isVisible}
+        onCancel={() => setIsVisible(false)}
+        footer={
+          <Button
+            key="submit"
+            type="primary"
+            href="#"
+            onClick={() => setIsVisible(false)}
+          >
+            {t("wallet.unlock_alert.confirm")}
+          </Button>
+        }
+      >
+        <p>{t("wallet.unlock_alert.tip")}</p>
+      </Modal>
+    </>
+  );
+};
+
+export const UnlockWalletAlert = connect(
+  (state: { wallet: IWalletState; signParams: SignParams }) => ({
+    account: (state.wallet || {}).account,
+    signParams: state.signParams
+  })
+)(UnlockWallet);

--- a/src/shared/wallet/wallet.tsx
+++ b/src/shared/wallet/wallet.tsx
@@ -17,6 +17,7 @@ import AccountSection from "./account-section";
 import { DeployPreloadHeader } from "./contract/deploy";
 import NewWallet from "./new-wallet";
 import UnlockWallet from "./unlock-wallet";
+import { UnlockWalletAlert } from "./unlock-wallet-alert";
 import { IWalletState, QueryType } from "./wallet-reducer";
 import { WalletTabs } from "./wallet-tabs";
 
@@ -85,7 +86,7 @@ class WalletInner extends PureComponent<Props, State> {
     const { createNew } = this.state;
     const { account } = this.props;
     return (
-      <>
+      <UnlockWalletAlert>
         <DeployPreloadHeader />
         <ContentPadding>
           <Row
@@ -109,7 +110,7 @@ class WalletInner extends PureComponent<Props, State> {
             </Col>
           </Row>
         </ContentPadding>
-      </>
+      </UnlockWalletAlert>
     );
   }
 }

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -472,4 +472,6 @@ wallet.whitelist.operation.delete: Delete
 wallet.whitelist.operation.edit: Edit
 wallet.whitelist.title_operation: Operation
 wallet.whitelist.operation.alert: Sure to cancel?
-
+wallet.unlock_alert.title: Unlock Wallet First
+wallet.unlock_alert.tip: Please unlock your wallet before perform other operations.
+wallet.unlock_alert.confirm: I know


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind backend-change
> /kind ui-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

show tip modal if wallet is not unlocked when receive message form dapp.

![WX20190911-214553](https://user-images.githubusercontent.com/20088392/64705703-f33bf100-d4e2-11e9-9ff6-f441a1c8dd4f.png)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #941 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
