### PR TITLE
Suppressed warning for source-map-loader

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -31,7 +31,15 @@ module.exports = {
   module: {
     rules: [
       { test: /\.tsx?$/, loader: "awesome-typescript-loader" },
-      { enforce: "pre", test: /\.js$/, loader: "source-map-loader" },
+      {
+        enforce: "pre",
+        test: /\.js$/,
+        loader: "source-map-loader",
+        exclude: [
+          path.resolve(__dirname, "./node_modules/ethereumjs-util"),
+          path.resolve(__dirname, "./node_modules/rlp")
+        ]
+      },
       {
         test: /\.js$/,
         exclude: /(node_modules)/,


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup
**What this PR does / why we need it**:
To fix the warnings we getting on **npm run watch** then I researched and found that we can exclude these to suppress warnings.
**Which issue(s) this PR fixes**:
Fixes #1049 
