### PR TITLE
displayed error when data is empty

### DIFF
--- a/src/shared/pages/address-details-page.tsx
+++ b/src/shared/pages/address-details-page.tsx
@@ -80,7 +80,7 @@ const AddressDetailsPage: React.FC<RouteComponentProps<{ address: string }>> = (
         }: QueryResult<{
           getAccount: GetAccountResponse;
         }>) => {
-          if (!loading && !data) {
+          if (!loading && (!data || Object.keys(data).length === 0)) {
             return (
               <ErrorPage
                 bg={assetURL("/action-not-found.png")}


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
To display the error page when data is empty.
**Which issue(s) this PR fixes**:
Fixes #1102 
