### PR TITLE
Fixed #1158: Action fee renderer error

### DIFF
--- a/src/shared/common/apollo-client.ts
+++ b/src/shared/common/apollo-client.ts
@@ -58,7 +58,7 @@ export const apolloClient = new ApolloClient({
 
 export const setApolloClientEndpoint = (url: string) => {
   apolloClientConfig.uri = url;
-  apolloClient.cache.reset();
+  apolloClient.resetStore();
   apolloClient.reFetchObservableQueries(true);
 };
 

--- a/src/shared/pages/action-list-page.tsx
+++ b/src/shared/pages/action-list-page.tsx
@@ -24,7 +24,7 @@ import { ActionFeeRenderer } from "../renderer/action-fee-renderer";
 import { ActionHashRenderer } from "../renderer/action-hash-renderer";
 import { Page } from "./page";
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 15;
 
 export function getAddress(record: ActionInfo): string {
   const addr: string =


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
This PR is to limit the request rate to GraphQL endpoint to 5 requests per second. 

**Which issue(s) this PR fixes**:
Fixes #1158 

**Special notes for your reviewer**:
The root cause of the issue is that too many requests to the GraphQL endpoint caused by the action fee renderer at the same time. 

**Does this PR introduce a user-facing change?**:
NONE
