### PR TITLE
go to same path when check out other domain

### DIFF
--- a/src/shared/common/top-menu-bar.tsx
+++ b/src/shared/common/top-menu-bar.tsx
@@ -141,13 +141,27 @@ const LanguageSwitcherMenu = () => {
   );
 };
 
+const goToRelatedNetPage = (uri: string): void => {
+  const { pathname, search } = location;
+  const domain =
+    uri.lastIndexOf("/") === uri.length - 1
+      ? uri.slice(0, uri.length - 1)
+      : uri;
+  const url = `${domain}${pathname}${search}`;
+  window.open(url, "target");
+};
+
 const renderMenuItem = (menu: INavMenuItem): JSX.Element => {
   const { path = "", items, label } = menu;
   if (!items) {
     return (
       <Menu.Item key={`menu-item-${label}`}>
         {path.match(/^https?:\/\//i) || path.match("/api-gateway/") ? (
-          <HoverableA href={path} target="_blank" rel="noreferrer">
+          <HoverableA
+            href="#"
+            onClick={() => goToRelatedNetPage(path)}
+            rel="noreferrer"
+          >
             {t(label)}
           </HoverableA>
         ) : (


### PR DESCRIPTION
**What type of PR is this?**
 bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1179

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
![image](https://user-images.githubusercontent.com/16171758/71882041-9689d380-316e-11ea-950b-c78bc44bc066.png)

1. Go to anyone page
2. Hover on the Mainnet within the menu
3. It will go to the same page in related environment if you click Mainnet/Testnet

```release-note

```
