### PR TITLE
add different hashroute for tabs

### DIFF
--- a/src/shared/pages/address-details-page.tsx
+++ b/src/shared/pages/address-details-page.tsx
@@ -53,6 +53,7 @@ const parseAddressDetails = (data: { getAccount: GetAccountResponse }) => {
   };
 };
 
+// tslint:disable-next-line:max-func-body-length
 const AddressDetailsPage: React.FC<RouteComponentProps<{ address: string }>> = (
   props
 ): JSX.Element | null => {
@@ -110,6 +111,11 @@ const AddressDetailsPage: React.FC<RouteComponentProps<{ address: string }>> = (
           });
           const { numActions = 0 } =
             get(data || {}, "getAccount.accountMeta") || {};
+          const hashRoute =
+            isBrowser && location.hash.includes("#")
+              ? location.hash.slice(1)
+              : "transactions";
+          const { history } = props;
           return (
             <ContentPadding>
               <CardDetails
@@ -129,14 +135,27 @@ const AddressDetailsPage: React.FC<RouteComponentProps<{ address: string }>> = (
                   valueRenderMap: AddressDetailRenderer
                 }}
               />
-              <Tabs size="large" className="card-shadow">
-                <Tabs.TabPane tab={t("common.transactions")} key="1">
+              <Tabs
+                size="large"
+                className="card-shadow"
+                defaultActiveKey={hashRoute}
+                onChange={key => {
+                  history.replace(`#${key}`);
+                }}
+              >
+                <Tabs.TabPane tab={t("common.transactions")} key="transactions">
                   <ActionTable numActions={numActions} address={address} />
                 </Tabs.TabPane>
-                <Tabs.TabPane tab={t("common.xrc20Transactions")} key="2">
+                <Tabs.TabPane
+                  tab={t("common.xrc20Transactions")}
+                  key="xrc_transactions"
+                >
                   <XRC20ActionTable address={address} />
                 </Tabs.TabPane>
-                <Tabs.TabPane tab={t("common.contract_transactions")} key="3">
+                <Tabs.TabPane
+                  tab={t("common.contract_transactions")}
+                  key="contract_transactions"
+                >
                   <EvmTransfersTable address={address} />
                 </Tabs.TabPane>
               </Tabs>


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1191

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

![image](https://user-images.githubusercontent.com/16171758/71881545-74438600-316d-11ea-985e-682b29332f24.png)

1. Go to address page
2. The url will change if you click different tabs that picture highlight.

```release-note

```
