### PR TITLE
Fixed #1291 errors failed to query analytics xrc20

### DIFF
--- a/src/shared/pages/xrc20-action-list-page.tsx
+++ b/src/shared/pages/xrc20-action-list-page.tsx
@@ -308,9 +308,11 @@ const XRC20ActionListPage: React.FC<
           <TabPane tab={t("pages.token")} key="1">
             <XRC20ActionTable address={address} />
           </TabPane>
-          <TabPane tab={t("pages.tokenHolders")} key="2">
-            <XRC20HoldersTable address={address} />
-          </TabPane>
+          {address && (
+            <TabPane tab={t("pages.tokenHolders")} key="2">
+              <XRC20HoldersTable address={address} />
+            </TabPane>
+          )}
         </Tabs>
       </ContentPadding>
     </>

--- a/src/shared/pages/xrc721-action-list-page.tsx
+++ b/src/shared/pages/xrc721-action-list-page.tsx
@@ -312,9 +312,11 @@ const XRC721ActionListPage: React.FC<
           <TabPane tab={t("pages.token")} key="1">
             <XRC721ActionTable address={address} />
           </TabPane>
-          <TabPane tab={t("pages.tokenHolders")} key="2">
-            <XRC721HoldersTable address={address} />
-          </TabPane>
+          {address && (
+            <TabPane tab={t("pages.tokenHolders")} key="2">
+              <XRC721HoldersTable address={address} />
+            </TabPane>
+          )}
         </Tabs>
       </ContentPadding>
     </>


### PR DESCRIPTION
**What type of PR is this?**
 bug

**What this PR does / why we need it**:
This PR is to fix the error while querying token holders for an empty token address. The fix is to disable the token holder's tab if there is no token address defined (tokentxns page ).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1291 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
