### PR TITLE
Fix #878 Return 404 for invalid action hash

### DIFF
--- a/src/shared/pages/action-detail-page.tsx
+++ b/src/shared/pages/action-detail-page.tsx
@@ -1,4 +1,3 @@
-import notification from "antd/lib/notification";
 import { get } from "dottie";
 import { fromRau } from "iotex-antenna/lib/account/utils";
 import { publicKeyToAddress } from "iotex-antenna/lib/crypto/crypto";
@@ -14,7 +13,6 @@ import {
   GetActionsResponse,
   GetReceiptByActionResponse
 } from "../../api-gateway/resolvers/antenna-types";
-import { ActionNotFound } from "../common/action-not-found";
 import { CardDetails } from "../common/card-details";
 import { NotFound } from "../common/not-found";
 import { PageNav } from "../common/page-nav-bar";
@@ -123,13 +121,10 @@ const parseActionDetails = (data: IActionsDetails) => {
 
 const ActionDetailPage: React.FC<RouteComponentProps<{ hash: string }>> = (
   props
-): JSX.Element | null => {
+): JSX.Element => {
   const { hash } = props.match.params;
-  if (hash && hash.length < 64) {
+  if (!hash || hash.length !== 64) {
     return <NotFound />;
-  }
-  if (!hash) {
-    return null;
   }
   return (
     <>
@@ -156,12 +151,7 @@ const ActionDetailPage: React.FC<RouteComponentProps<{ hash: string }>> = (
       >
         {({ error, data, loading, stopPolling }: GetActionDetailsResponse) => {
           if (error || (!loading && (!data || !data.action || !data.receipt))) {
-            if (error) {
-              notification.error({
-                message: `failed to get bp stats in VodesCard: ${error}`
-              });
-            }
-            return <ActionNotFound />;
+            return <NotFound />;
           }
           if (data && data.action) {
             stopPolling();

--- a/src/shared/pages/action-detail-page.tsx
+++ b/src/shared/pages/action-detail-page.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../api-gateway/resolvers/antenna-types";
 import { ActionNotFound } from "../common/action-not-found";
 import { CardDetails } from "../common/card-details";
+import { NotFound } from "../common/not-found";
 import { PageNav } from "../common/page-nav-bar";
 import { ContentPadding } from "../common/styles/style-padding";
 import { Dict } from "../common/types";
@@ -124,6 +125,9 @@ const ActionDetailPage: React.FC<RouteComponentProps<{ hash: string }>> = (
   props
 ): JSX.Element | null => {
   const { hash } = props.match.params;
+  if (hash && hash.length < 64) {
+    return <NotFound />;
+  }
   if (!hash) {
     return null;
   }
@@ -157,7 +161,7 @@ const ActionDetailPage: React.FC<RouteComponentProps<{ hash: string }>> = (
                 message: `failed to get bp stats in VodesCard: ${error}`
               });
             }
-            return <ActionNotFound info={hash} />;
+            return <ActionNotFound />;
           }
           if (data && data.action) {
             stopPolling();


### PR DESCRIPTION
**What type of PR is this?**
 bug

**What this PR does / why we need it**:
This PR is to return 404 status code for an invalid action hash in terms of hash length (64). If the hash length valid we still need to return status 200 for checking pending hash.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #878 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
