### PR TITLE
Fix incorrect display of Age (50 years) in action-list-page

### DIFF
--- a/src/shared/pages/action-list-page.tsx
+++ b/src/shared/pages/action-list-page.tsx
@@ -263,7 +263,7 @@ const getActionByTypeColumns = (): Array<ColumnProps<IActionByTypeInfo>> => [
     title: t("block.timestamp"),
     dataIndex: "timeStamp",
     width: "8vw",
-    render: (_, { timeStamp }) => moment(parseInt(timeStamp, 10)).fromNow()
+    render: (_, { timeStamp }) => moment.unix(parseInt(timeStamp, 10)).fromNow()
   },
   {
     title: t("action.sender"),


### PR DESCRIPTION
Fixes #1298 
This commit will fix the incorrect display on the action-list-page.
