### PR TITLE
change failed action icon to use the yellow one #1409

### DIFF
--- a/src/shared/renderer/action-hash-renderer.tsx
+++ b/src/shared/renderer/action-hash-renderer.tsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 import { Dict } from "../common/types";
 import { VerticalTableRender } from "../common/vertical-table";
 import { GET_ACTION_DETAILS_STATUS_BY_HASH } from "../queries";
-
+import { colors } from "../common/styles/style-color";
 export interface IActionsDetails {
   receipt?: {
     receiptInfo: {
@@ -38,15 +38,17 @@ const ActionHashRenderer: VerticalTableRender<string> = ({ value }) => {
               return null;
             }
             const status = parseStatus(data || {});
-            if (loading || status === "Success") {
+            if (loading || `${status}`.match(/success/i)) {
               return null;
             }
             return (
-              <Icon
-                type="info-circle"
-                theme="filled"
-                style={{ color: "#EE3423" }}
-              />
+              <>
+                <Icon
+                  type="exclamation-circle"
+                  style={{ color: colors.warning }}
+                />
+                &nbsp;
+              </>
             );
           }}
         </Query>


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind backend-change
> /kind ui-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
![Screen Shot 2020-07-23 at 11 45 56 AM](https://user-images.githubusercontent.com/34900782/88307997-8c7a8d00-ccda-11ea-9370-0932891364fc.png)
