### PR TITLE
Hotfix/resolve issue #1579

### DIFF
--- a/src/client/stylesheets/main.less
+++ b/src/client/stylesheets/main.less
@@ -372,9 +372,31 @@ input {
   padding-bottom: 32px !important;
 }
 
-.claimButton > .ant-btn:first-child {
-  padding: 0 !important;
-  border: 0 !important;
+.claimButton {
+  button:nth-child(1) {
+    border-width: 0 !important;
+  }
+  .ant-btn:first-child {
+    padding: 0 !important;
+  }
+  a {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    box-shadow: none;
+    box-sizing: border-box;
+    width: 55px;
+    background: #fff !important;
+    border: 1px solid #d9d9d9 !important;
+    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    &.disabled {
+      pointer-events: none;
+      cursor: not-allowed;
+      border: 1px solid #d9d9d9 !important;
+    }
+  }
 }
 text.recharts-text.recharts-cartesian-axis-tick-value {
   font-size: 12px;

--- a/src/shared/wallet/account-section.tsx
+++ b/src/shared/wallet/account-section.tsx
@@ -102,6 +102,9 @@ class AccountSection extends React.Component<Props, State> {
     claimableAmount: 0,
     showBalance: false
   };
+  public get tagClassName(): string {
+    return !this.state.claimable ? "ant-btn disabled" : "ant-btn";
+  }
 
   private pollAccountInterval: number | undefined;
 
@@ -522,7 +525,7 @@ class AccountSection extends React.Component<Props, State> {
         >
           {
             // @ts-ignore
-            <Button
+            <a
               type="primary"
               style={{
                 borderTopLeftRadius: 4,
@@ -530,10 +533,11 @@ class AccountSection extends React.Component<Props, State> {
                 boxShadow: "none"
               }}
               onClick={this.onClaimClickHandle(token)}
-              disabled={!this.state.claimable}
+              className={this.tagClassName}
+              href={""}
             >
               {t("account.claim")}
-            </Button>
+            </a>
           }
         </Dropdown.Button>
       </Badge>

--- a/src/shared/wallet/transfer/transfer.tsx
+++ b/src/shared/wallet/transfer/transfer.tsx
@@ -69,12 +69,7 @@ class TransferForm extends React.PureComponent<Props, State> {
     this.updateGasCostLimit(this.props.form);
   }
   public isDisconnected(): boolean {
-    return !navigator.onLine;
-  }
-  public componentWillUnmount(): void {
-    window.removeEventListener("offline", () => {
-      // Remove listener when component destroy.
-    });
+    return navigator.onLine;
   }
 
   public sendTransfer = async (status: boolean) => {
@@ -323,6 +318,7 @@ class TransferForm extends React.PureComponent<Props, State> {
             type="primary"
             loading={sending}
             onClick={this.showConfirmTransfer}
+            disabled={this.isDisconnected()}
           >
             {t("wallet.transactions.send")}
           </Button>

--- a/src/shared/wallet/transfer/transfer.tsx
+++ b/src/shared/wallet/transfer/transfer.tsx
@@ -53,7 +53,6 @@ type State = {
   showConfirmTransfer: boolean;
   showDataHex: boolean;
   gasCostLimit: string;
-  disconnected: boolean;
 };
 
 class TransferForm extends React.PureComponent<Props, State> {
@@ -63,42 +62,16 @@ class TransferForm extends React.PureComponent<Props, State> {
     broadcast: null,
     showConfirmTransfer: false,
     showDataHex: true,
-    gasCostLimit: "",
-    disconnected: true
+    gasCostLimit: ""
   };
 
   public componentDidMount(): void {
     this.updateGasCostLimit(this.props.form);
-    this.checkConnect();
   }
-  public checkConnect(): void {
-    if (isElectron()) {
-      window.addEventListener("offline", () => {
-        this.setState({
-          disconnected: true
-        });
-        notification.error({
-          message: t("network.disconnected"),
-          duration: 5
-        });
-      });
-    } else {
-      const disconnected = !window.navigator.onLine;
-      this.setState({
-        disconnected: disconnected
-      });
-      if (disconnected) {
-        notification.error({
-          message: t("network.disconnected"),
-          duration: 5
-        });
-      }
-    }
+  public isDisconnected(): boolean {
+    return !navigator.onLine;
   }
   public componentWillUnmount(): void {
-    // this.setState = (state: State, callback: () => void) => {
-    //   return;
-    // };
     window.removeEventListener("offline", () => {
       // Remove listener when component destroy.
     });
@@ -197,7 +170,14 @@ class TransferForm extends React.PureComponent<Props, State> {
     });
   };
 
-  public showConfirmTransfer = () => {
+  public showConfirmTransfer = async () => {
+    if (this.isDisconnected()) {
+      notification.error({
+        message: t("network.disconnected"),
+        duration: 5
+      });
+      return;
+    }
     this.props.form.validateFields(err => {
       if (err) {
         return;
@@ -343,7 +323,6 @@ class TransferForm extends React.PureComponent<Props, State> {
             type="primary"
             loading={sending}
             onClick={this.showConfirmTransfer}
-            disabled={this.state.disconnected}
           >
             {t("wallet.transactions.send")}
           </Button>

--- a/src/shared/wallet/transfer/transfer.tsx
+++ b/src/shared/wallet/transfer/transfer.tsx
@@ -96,9 +96,9 @@ class TransferForm extends React.PureComponent<Props, State> {
     }
   }
   public componentWillUnmount(): void {
-    this.setState = (state: State, callback: () => void) => {
-      return;
-    };
+    // this.setState = (state: State, callback: () => void) => {
+    //   return;
+    // };
     window.removeEventListener("offline", () => {
       // Remove listener when component destroy.
     });

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -8,6 +8,7 @@ topbar.home: Home
 not_found.bar: 'Nicht gefunden'
 not_found.title: Oops!
 not_found.info: 'Wir können die Seite nicht finden...'
+network.disconnected: 'Die Verbindung zum Internet ist nicht möglich'
 candidate.delegate_name: 'Name des Delegierten'
 candidate.status: Status
 candidate.live_votes: 'Aktuelle Stimmen'

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -280,6 +280,7 @@ new-wallet.warn.secure: 'Secure it like the millions of dollars it may one day b
 new-wallet.warn.stolen: 'Your funds will be stolen if you use this file on a malicious/phishing site.'
 not_found.bar: 'Not Found'
 not_found.info: 'We cannot find the page for you...'
+network.disconnected: 'Can not connecting to internet...'
 not_found.title: Oops!
 page_navs.block: "Block #${height}"
 pages.token: Token Transfers

--- a/translations/it.yaml
+++ b/translations/it.yaml
@@ -8,6 +8,7 @@ topbar.home: HOME
 not_found.bar: 'Non trovato'
 not_found.title: Oops!
 not_found.info: 'Non riusciamo a trovare la pagina che hai richiesto...'
+network.disconnected: 'Impossibile connettersi a Internet'
 candidate.delegate_name: 'Nome del Delegato'
 candidate.status: Stato
 candidate.live_votes: 'Voti Live'

--- a/translations/zh-CN.yaml
+++ b/translations/zh-CN.yaml
@@ -10,6 +10,7 @@ topbar.top_accounts: IOTX余额最高账户
 not_found.bar: 未找到
 not_found.title: 糟糕!
 not_found.info: 找不到页面...
+network.disconnected: '无法连接到互联网'
 candidate.delegate_name: 节点名称
 candidate.status: 状态
 candidate.live_votes: 实时投票


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind backend-change
> /kind ui-change
 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes #1579 , And find a exist button tag nested error.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1579
**Special notes for your reviewer**:
Find a exist bug:
![warnning](https://user-images.githubusercontent.com/26297704/92636911-b9c2df00-f30a-11ea-94d1-80f19e0db07f.png)
the reason is button tag nested:
![nested](https://user-images.githubusercontent.com/26297704/92636915-bb8ca280-f30a-11ea-8038-2d401f94c5af.png)
resolve:
![after](https://user-images.githubusercontent.com/26297704/92636920-bd566600-f30a-11ea-8a6b-195a48b4cf51.png)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
1. Nested `<button>` case, rename child node to <a> and fixed css style.
2. fix #1579
```
