### PR TITLE
fix: 1. remove uppercase 2. use overflow:hidden to make breadcrumb on…

### DIFF
--- a/src/client/stylesheets/main.less
+++ b/src/client/stylesheets/main.less
@@ -568,10 +568,12 @@ span.ellipsis-text {
 }
 
 .wordwrap {
-  white-space: pre-wrap;
-  white-space: -moz-pre-wrap;
-  white-space: -o-pre-wrap;
+  white-space: nowrap;
+  white-space: -moz-nowrap;
+  white-space: -o-nowrap;
   word-break: break-all;
+  text-overflow: clip;
+  overflow: hidden;
 }
 
 .bg-light {

--- a/src/shared/common/page-nav-bar.tsx
+++ b/src/shared/common/page-nav-bar.tsx
@@ -14,12 +14,7 @@ const PageNav: React.FC<{ items: Array<JSX.Element | string> }> = ({
   return (
     <ContentPadding style={{ margin: "16px 0" }}>
       <Row type="flex" justify="space-between" align="top" gutter={20}>
-        <Col
-          xs={24}
-          sm={24}
-          md={16}
-          style={{ marginBottom: "16px", textTransform: "uppercase" }}
-        >
+        <Col xs={24} sm={24} md={16} style={{ marginBottom: "16px" }}>
           <Breadcrumb separator=">" className="wordwrap">
             <Breadcrumb.Item>
               <Link to="/" style={{ whiteSpace: "nowrap" }}>


### PR DESCRIPTION
…e line

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind backend-change
> /kind ui-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
<img width="794" alt="WechatIMG6" src="https://user-images.githubusercontent.com/26403700/93008121-e34a6780-f5a3-11ea-8af6-29559bb5e7ca.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1614 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
