### PR TITLE
fix: 1. improve display xrc20 symbol and name 2. fix document title

### DIFF
--- a/src/shared/common/xrc20-token.tsx
+++ b/src/shared/common/xrc20-token.tsx
@@ -24,7 +24,11 @@ const XRC20TokenName: React.FC<{ contract: string }> = ({ contract }) => {
     });
   const [name, setName] = useState("");
   const [address, setAddress] = useState("");
-  return <LinkButton href={`/token/${address}`}>{name}</LinkButton>;
+  return (
+    <LinkButton href={`/token/${address}`} style={{ whiteSpace: "nowrap" }}>
+      {name}
+    </LinkButton>
+  );
 };
 
 const XRC20TokenUnit: React.FC<{ contract: string }> = ({ contract }) => {

--- a/src/shared/pages/xrc20-action-list-page.tsx
+++ b/src/shared/pages/xrc20-action-list-page.tsx
@@ -553,14 +553,10 @@ const XRC20ActionListPage: React.FC<
       });
     }
   }
-
+  const prefix = baseInfo.name ? `${baseInfo.name} (${baseInfo.symbol})` : "";
   return (
     <>
-      <Helmet
-        title={`${baseInfo.name} (${baseInfo.symbol}) ${t(
-          "pages.tokenTracker"
-        )} | iotexscan`}
-      />
+      <Helmet title={`${prefix} ${t("pages.tokenTracker")} | iotexscan`} />
       <PageNav
         items={[
           <FlexLink

--- a/src/shared/renderer/token-name-renderer.tsx
+++ b/src/shared/renderer/token-name-renderer.tsx
@@ -20,8 +20,9 @@ const TokenNameRenderer = (props: InputProps) => {
             style={{ width: "13px", height: "13px" }}
           />
         )}
-        <span style={{ marginLeft: "2px" }}>{props.name}</span>
-        {props.symbol && <span>({props.symbol})</span>}
+        <span style={{ marginLeft: "2px", whiteSpace: "nowrap" }}>{`${
+          props.name
+        } (${props.symbol || ""})`}</span>
       </div>
     </LinkButton>
   );


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind backend-change
> /kind ui-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1699

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<img width="202" alt="WX20201115-104415@2x" src="https://user-images.githubusercontent.com/26403700/99161711-e68eda80-272f-11eb-9265-2e0247bac750.png">

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
